### PR TITLE
Ping Slackbot instead of Scrappy

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -36,4 +36,4 @@ app.use(urlencoded({ verify: rawBodyBuffer, extended: true }));
 app.use(json({ verify: rawBodyBuffer }));
 
 await app.listen(process.env.PORT ?? 3000);
-await new WebClient(process.env.TOKEN).chat.postMessage({ channel: 'C016T0E6QHW', text: "I'm a‎live! Missed me yet, <@U015D6A36AG>?" });
+await new WebClient(process.env.TOKEN).chat.postMessage({ channel: 'C016T0E6QHW', text: "I'm a‎live! Missed me yet, <@USLACKBOT>?" });


### PR DESCRIPTION
@scrappy keeps crashing I'm not sure why but maybe because they're being pinged a lot? Idk if it works that way, but this PR makes Netherite Golem ping Slackbot instead.